### PR TITLE
Added jobId field for vacancy

### DIFF
--- a/src/main/java/com/fakng/fakngagrgtr/parser/amazon/AmazonParser.java
+++ b/src/main/java/com/fakng/fakngagrgtr/parser/amazon/AmazonParser.java
@@ -26,6 +26,7 @@ public class AmazonParser extends ApiParser {
 
     // Amazon doesn't allow to get more than 10000 vacancies.
     private static final int MAX_VACANCIES_COUNT = 10000;
+    private static final String JOB_URL_FORMAT = "https://www.amazon.jobs%s";
     private static final DateTimeFormatter DATE_TIME_FORMATTER =
             DateTimeFormatter.ofPattern("MMMM d, u", Locale.ENGLISH);
 
@@ -71,6 +72,7 @@ public class AmazonParser extends ApiParser {
         Vacancy vacancy = new Vacancy();
         vacancy.setTitle(dto.getTitle());
         vacancy.setUrl(parseUrl(dto));
+        vacancy.setJobId(dto.getIdIcims());
         vacancy.setPublishedDate(parseLocalDateTime(dto));
         vacancy.setCompany(company);
         vacancy.addLocation(parseLocation(dto));
@@ -79,7 +81,7 @@ public class AmazonParser extends ApiParser {
     }
 
     private String parseUrl(VacancyDTO dto) {
-        return "https://www.amazon.jobs" + dto.getJobPath();
+        return String.format(JOB_URL_FORMAT, dto.getJobPath());
     }
 
     private LocalDateTime parseLocalDateTime(VacancyDTO dto) {

--- a/src/main/java/com/fakng/fakngagrgtr/parser/google/GoogleParser.java
+++ b/src/main/java/com/fakng/fakngagrgtr/parser/google/GoogleParser.java
@@ -62,6 +62,7 @@ public class GoogleParser extends ApiParser {
         vacancy.setId(parseVacancyId(dto.getId()));
         vacancy.setTitle(dto.getTitle());
         vacancy.setUrl(dto.getApplyUrl());
+        vacancy.setJobId(parseJobId(dto.getId()));
         if (dto.getPublishDate() != null) {
             vacancy.setPublishedDate(parseLocalDateTime(dto.getPublishDate()));
         }
@@ -69,6 +70,10 @@ public class GoogleParser extends ApiParser {
         processLocations(vacancy, dto.getLocations());
         vacancy.setDescription(generateFullDescription(dto));
         return vacancy;
+    }
+
+    private String parseJobId(String jobId) {
+        return jobId.substring(jobId.indexOf("/") + 1);
     }
 
     private void processLocations(Vacancy vacancy, List<LocationDTO> locations) {

--- a/src/main/java/com/fakng/fakngagrgtr/persistent/vacancy/Vacancy.java
+++ b/src/main/java/com/fakng/fakngagrgtr/persistent/vacancy/Vacancy.java
@@ -30,6 +30,9 @@ public class Vacancy {
     @Column(name = "url", length = 512, nullable = false)
     private String url;
 
+    @Column(name = "job_id", length = 32, nullable = false)
+    private String jobId;
+
     @Column(name = "add_date")
     @CreationTimestamp
     private LocalDateTime addDate;

--- a/src/main/resources/db/changelog/init.sql
+++ b/src/main/resources/db/changelog/init.sql
@@ -36,6 +36,7 @@ CREATE TABLE vacancy
     id          BIGINT                   NOT NULL DEFAULT nextval('vacancy_seq') PRIMARY KEY,
     title       VARCHAR(128)             NOT NULL,
     description VARCHAR                  NOT NULL,
+    job_id      VARCHAR(32)              NOT NULL,
     url         VARCHAR                  NOT NULL,
     company_id  INT                      NOT NULL,
     location_id BIGINT                   NOT NULL,

--- a/src/test/java/com/fakng/fakngagrgtr/parser/GoogleParserTest.java
+++ b/src/test/java/com/fakng/fakngagrgtr/parser/GoogleParserTest.java
@@ -75,6 +75,7 @@ public class GoogleParserTest extends AbstractParserTest {
         first.setId(1L);
         first.setTitle("title_1");
         first.setUrl("apply_url_1");
+        first.setJobId("1");
         first.setCompany(company);
         first.setDescription("description_1\nsummary_1\nqualifications_1\nresponsibilities_1\ninstructions_1\nHas remote: true");
         first.setLocations(company.getLocations());
@@ -84,6 +85,7 @@ public class GoogleParserTest extends AbstractParserTest {
         second.setId(2L);
         second.setTitle("title_2");
         second.setUrl("apply_url_2");
+        second.setJobId("2");
         second.setCompany(company);
         second.setDescription("description_2\nsummary_2\nqualifications_2\nresponsibilities_2\ninstructions_2\nHas remote: false");
         second.setLocations(company.getLocations().isEmpty() ? new ArrayList<>() : company.getLocations().subList(0, 1));
@@ -97,6 +99,7 @@ public class GoogleParserTest extends AbstractParserTest {
         assertEquals(expected.getTitle(), actual.getTitle());
         assertEquals(expected.getDescription(), actual.getDescription());
         assertEquals(expected.getUrl(), actual.getUrl());
+        assertEquals(expected.getJobId(), actual.getJobId());
         assertEquals(expected.getCompany().getId(), actual.getCompany().getId());
         assertEquals(expected.getLocations().size(), actual.getLocations().size());
         for (int i = 0; i < expected.getLocations().size(); i++) {


### PR DESCRIPTION
There's an id field we have for a vacancy in DB. It's just the primary key
But usually, vacancies on different sites also have their own id - job_id
This field is introduced to store this one. Later it will allow identifying a specific vacancy from a specific site.